### PR TITLE
adjust configuration for assets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 8.0.2"
 # The modern asset pipeline for Rails [https://github.com/rails/propshaft]
-gem "propshaft"
+# gem "propshaft"
 # Use postgresql as the database for Active Record
 gem "pg", "~> 1.1"
 # Use the Puma web server [https://github.com/puma/puma]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,11 +221,6 @@ GEM
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
-    propshaft (1.1.0)
-      actionpack (>= 7.0.0)
-      activesupport (>= 7.0.0)
-      rack
-      railties (>= 7.0.0)
     psych (5.2.3)
       date
       stringio
@@ -234,7 +229,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.1.12)
+    rack (3.1.13)
     rack-proxy (0.7.7)
       rack
     rack-session (2.1.0)
@@ -420,7 +415,6 @@ DEPENDENCIES
   jsbundling-rails (~> 1.3)
   kamal
   pg (~> 1.1)
-  propshaft
   puma (>= 5.0)
   rails (~> 8.0.2)
   rubocop-rails-omakase

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,4 +1,5 @@
 //= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js
 //= link application.scss
-//= link application.css//= link_tree ../builds
+//= link application.css
+//= link_tree ../builds

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,7 +1,7 @@
 @import "bootstrap";
 
 // Your CSS partials
-@import "components/_navbar";
+@import "components/navbar";
 // @import "components/alert";
 @import "components/footer";
 // @import "components/subjects_index";
@@ -40,6 +40,7 @@ body {
   height: 100%;
   margin: 0px;
   cursor: url("https://img.icons8.com/dusk/50/000000/hand-cursor.png"), auto;
+  padding-bottom: 100px; 
 }
 
 a {

--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -20,7 +20,9 @@ $pink: #F0688C;
   box-shadow: rgba(50, 50, 93, 0.25) 0px 50px 100px -20px,
   rgba(0, 0, 0, 0.3) 0px 30px 60px -30px,
   rgba(10, 37, 64, 0.35) 0px -2px 6px 0px inset;
+  z-index: 10;  /* Ensure footer stays on top */
 }
+
 
 .footer-links {
   display: flex;

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -1,3 +1,10 @@
+$dyslexia_background: #FFFBF7;
+$orange: #F59435;
+$light_green: #CDE17B;
+$turquoise: #7AC4BD;
+$purple: #A81375;
+$pink: #F0688C;
+
 #logo img {
   width: 50px;
   height: auto;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>MathSprint</title>
+    <%= tag.link rel: 'icon', href: 'https://res.cloudinary.com/dm37aktki/image/upload/v1744731396/MentalMaths/Untitled_design_v7znkg.png', type: 'image/png' %>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,7 +1,7 @@
 <div class="navbar navbar-expand-sm navbar-light navbar-lewagon fixed-top">
   <%= link_to :root, class: "navbar-brand d-flex align-items-center" do %>
     <div id="logo" class="p-2">
-      <%= image_tag("https://res.cloudinary.com/dm37aktki/image/upload/v1651265304/Depositphotos_386432104_S_lbpstp.jpg") %>
+      <%= image_tag("https://res.cloudinary.com/dm37aktki/image/upload/v1744731396/MentalMaths/Untitled_design_v7znkg.png") %>
     </div>
     <div class="px-3">
       <h1 class="mb-0" id="nav-title">MathSprint</h1>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -2,6 +2,8 @@
 
 # Version of your assets, change this if you want to expire all your assets.
 Rails.application.config.assets.version = "1.0"
+Rails.application.config.assets.paths << Rails.root.join("app", "assets", "stylesheets")
+Rails.application.config.assets.precompile += %w[ application.js application.css ]
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path


### PR DESCRIPTION
assets were not being displayed properly because of improper pipeline configuration. confusion was made between sprocker popshaft and web packer. this PR adjusts configurations to remove conflicts and properly load all styling for assets