### PR TITLE
Remove Extra form on Turbo Load

### DIFF
--- a/app/javascript/packs/main.js
+++ b/app/javascript/packs/main.js
@@ -4,7 +4,5 @@ import 'bootstrap';
 import "@hotwired/turbo-rails";
 import '@babel/polyfill';
 import Rails from "@rails/ujs";
-import('./topic12_with_timer');
-import('./topic12_without_timer');
 
 Rails.start();

--- a/app/javascript/packs/topic12_with_timer.js
+++ b/app/javascript/packs/topic12_with_timer.js
@@ -17,7 +17,7 @@
   const gameContent = document.createElement('div');
   gameContent.innerHTML = `
     <div class="devise-form">
-      <div class="form-table" id="game-content">
+      <div class="form-table">
         <label id="start-input">Start Number: <input type="number" id="start-number" min="0" max="200" required></label><br>
         <label id="step-input">Count By: <input type="number" id="step-amount" min="1" max="200" required></label><br><br>
         <button class="devise-btn" id="start-game-btn">Start Game</button>

--- a/app/javascript/packs/topic12_without_timer.js
+++ b/app/javascript/packs/topic12_without_timer.js
@@ -15,7 +15,7 @@
   const gameContent = document.createElement('div');
   gameContent.innerHTML = `
     <div class="devise-form">
-      <div class="form-table" id="game-content">
+      <div class="form-table">
         <label id="start-input">Start Number: <input type="number" id="start-number" min="0" max="200" required></label><br>
         <label id="step-input">Count By: <input type="number" id="step-amount" min="1" max="200" required></label><br><br>
         <button class="devise-btn" id="start-game-btn">Start Game</button>

--- a/app/javascript/packs/topic13_with_timer.js
+++ b/app/javascript/packs/topic13_with_timer.js
@@ -17,7 +17,7 @@
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
       <div class="devise-form">
-        <div class="form-table" id="game-content">
+        <div class="form-table">
           <label id="start-input">Start Number: <input type="number" id="start-number" min="0" max="200" required></label><br><br><br>
           <button class="devise-btn" id="start-game-btn">Start Game</button>
           <div id="question-section" style="display: none;">

--- a/app/javascript/packs/topic13_without_timer.js
+++ b/app/javascript/packs/topic13_without_timer.js
@@ -14,7 +14,7 @@
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
       <div class="devise-form">
-        <div class="form-table" id="game-content">
+        <div class="form-table">
           <label id="start-input">Start Number: <input type="number" id="start-number" min="0" max="200" required></label><br><br><br>
           <button class="devise-btn" id="start-game-btn">Start Game</button>
           <div id="question-section" style="display: none;">

--- a/app/javascript/packs/topic14_with_timer.js
+++ b/app/javascript/packs/topic14_with_timer.js
@@ -17,7 +17,7 @@
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
       <div class="devise-form">
-        <div class="form-table" id="game-content">
+        <div class="form-table">
           <label id="start-input">Start Number: <input type="number" id="start-number" min="0" max="200" required></label><br><br><br>
           <button class="devise-btn" id="start-game-btn">Start Game</button>
           <div id="question-section" style="display: none;">

--- a/app/javascript/packs/topic14_without_timer.js
+++ b/app/javascript/packs/topic14_without_timer.js
@@ -14,7 +14,7 @@
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
       <div class="devise-form">
-        <div class="form-table" id="game-content">
+        <div class="form-table">
           <label id="start-input">Start Number: <input type="number" id="start-number" min="0" max="200" required></label><br><br><br>
           <button class="devise-btn" id="start-game-btn">Start Game</button>
           <div id="question-section" style="display: none;">

--- a/app/javascript/packs/topic15_with_timer.js
+++ b/app/javascript/packs/topic15_with_timer.js
@@ -17,7 +17,7 @@
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
       <div class="devise-form">
-        <div class="form-table" id="game-content">
+        <div class="form-table">
           <div id="question-section" style="display: none;">
             <p>You have <span id="timer">60</span> seconds.</p>
             <p id="question-text"></p>

--- a/app/javascript/packs/topic15_without_timer.js
+++ b/app/javascript/packs/topic15_without_timer.js
@@ -14,7 +14,7 @@
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
       <div class="devise-form">
-        <div class="form-table" id="game-content">
+        <div class="form-table">
           <div id="question-section" style="display: none;">
             <p id="question-text"></p>
             <input type="number" id="answer-input" />

--- a/app/javascript/packs/topic16_with_timer.js
+++ b/app/javascript/packs/topic16_with_timer.js
@@ -17,7 +17,7 @@
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
       <div class="devise-form">
-        <div class="form-table" id="game-content">
+        <div class="form-table">
           <div id="question-section" style="display: none;">
             <p>You have <span id="timer">60</span> seconds.</p>
             <p id="question-text"></p>

--- a/app/javascript/packs/topic16_without_timer.js
+++ b/app/javascript/packs/topic16_without_timer.js
@@ -14,7 +14,7 @@
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
       <div class="devise-form">
-        <div class="form-table" id="game-content">
+        <div class="form-table">
           <div id="question-section" style="display: none;">
             <p id="question-text"></p>
             <input type="number" id="answer-input" />

--- a/app/javascript/packs/topic17_with_timer.js
+++ b/app/javascript/packs/topic17_with_timer.js
@@ -17,7 +17,7 @@
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
       <div class="devise-form">
-        <div class="form-table" id="game-content">
+        <div class="form-table">
           <div id="question-section" style="display: none;">
             <p>You have <span id="timer">60</span> seconds.</p>
             <p id="question-text"></p>

--- a/app/javascript/packs/topic17_without_timer.js
+++ b/app/javascript/packs/topic17_without_timer.js
@@ -14,7 +14,7 @@
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
       <div class="devise-form">
-        <div class="form-table" id="game-content">
+        <div class="form-table">
           <div id="question-section" style="display: none;">
             <p id="question-text"></p>
             <input type="number" id="answer-input" />

--- a/app/javascript/packs/topic18_with_timer.js
+++ b/app/javascript/packs/topic18_with_timer.js
@@ -17,7 +17,7 @@
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
       <div class="devise-form">
-        <div class="form-table" id="game-content">
+        <div class="form-table">
           <div id="question-section" style="display: none;">
             <p>You have <span id="timer">60</span> seconds.</p>
             <p id="question-text"></p>

--- a/app/javascript/packs/topic18_without_timer.js
+++ b/app/javascript/packs/topic18_without_timer.js
@@ -14,7 +14,7 @@
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
       <div class="devise-form">
-        <div class="form-table" id="game-content">
+        <div class="form-table">
           <div id="question-section" style="display: none;">
             <p id="question-text"></p>
             <input type="number" id="answer-input" />

--- a/app/javascript/packs/topic19_with_timer.js
+++ b/app/javascript/packs/topic19_with_timer.js
@@ -17,7 +17,7 @@
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
       <div class="devise-form">
-        <div class="form-table" id="game-content">
+        <div class="form-table">
           <div id="question-section" style="display: none;">
             <p>You have <span id="timer">60</span> seconds.</p>
             <p id="question-text"></p>

--- a/app/javascript/packs/topic19_without_timer.js
+++ b/app/javascript/packs/topic19_without_timer.js
@@ -14,7 +14,7 @@
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
       <div class="devise-form">
-        <div class="form-table" id="game-content">
+        <div class="form-table">
           <div id="question-section" style="display: none;">
             <p id="question-text"></p>
             <input type="number" id="answer-input" />

--- a/app/javascript/packs/topic1_with_timer.js
+++ b/app/javascript/packs/topic1_with_timer.js
@@ -16,8 +16,8 @@
     // Create form for inputs
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
-      <div class="devise-form">
-        <div class="form-table" id="game-content">
+      <div class="devise-form form-table">
+        <div class="form-table">
           <div id="question-section" style="display: none;">
             <p>You have <span id="timer">60</span> seconds.</p>
             <p id="question-text"></p>

--- a/app/javascript/packs/topic1_without_timer.js
+++ b/app/javascript/packs/topic1_without_timer.js
@@ -13,7 +13,7 @@
     // Create form for inputs
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
-      <div class="devise-form">
+      <div class="devise-form form-table">
         <div class="form-table" id="game-content">
           <div id="question-section" style="display: none;">
             <p id="question-text"></p>

--- a/app/javascript/packs/topic20_with_timer.js
+++ b/app/javascript/packs/topic20_with_timer.js
@@ -17,7 +17,7 @@
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
       <div class="devise-form">
-        <div class="form-table" id="game-content">
+        <div class="form-table">
           <div id="question-section" style="display: none;">
             <p>You have <span id="timer">60</span> seconds.</p>
             <p id="question-text"></p>

--- a/app/javascript/packs/topic20_without_timer.js
+++ b/app/javascript/packs/topic20_without_timer.js
@@ -14,7 +14,7 @@
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
       <div class="devise-form">
-        <div class="form-table" id="game-content">
+        <div class="form-table">
           <div id="question-section" style="display: none;">
             <p id="question-text"></p>
             <input type="number" id="answer-input" />

--- a/app/javascript/packs/topic21_with_timer.js
+++ b/app/javascript/packs/topic21_with_timer.js
@@ -17,7 +17,7 @@
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
       <div class="devise-form">
-        <div class="form-table" id="game-content">
+        <div class="form-table">
           <div id="question-section" style="display: none;">
             <p>You have <span id="timer">60</span> seconds.</p>
             <p id="question-text"></p>

--- a/app/javascript/packs/topic21_without_timer.js
+++ b/app/javascript/packs/topic21_without_timer.js
@@ -14,7 +14,7 @@
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
       <div class="devise-form">
-        <div class="form-table" id="game-content">
+        <div class="form-table">
           <div id="question-section" style="display: none;">
             <p id="question-text"></p>
             <input type="number" id="answer-input" />

--- a/app/javascript/packs/topic22_with_timer.js
+++ b/app/javascript/packs/topic22_with_timer.js
@@ -17,7 +17,7 @@
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
       <div class="devise-form">
-        <div class="form-table" id="game-content">
+        <div class="form-table">
           <div id="question-section" style="display: none;">
             <p>You have <span id="timer">60</span> seconds.</p>
             <p id="question-text"></p>

--- a/app/javascript/packs/topic22_without_timer.js
+++ b/app/javascript/packs/topic22_without_timer.js
@@ -14,7 +14,7 @@
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
       <div class="devise-form">
-        <div class="form-table" id="game-content">
+        <div class="form-table">
           <div id="question-section" style="display: none;">
             <p id="question-text"></p>
             <input type="number" id="answer-input" />

--- a/app/javascript/packs/topic23_with_timer.js
+++ b/app/javascript/packs/topic23_with_timer.js
@@ -17,7 +17,7 @@
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
       <div class="devise-form">
-        <div class="form-table" id="game-content">
+        <div class="form-table">
           <div id="question-section" style="display: none;">
             <p>You have <span id="timer">60</span> seconds.</p>
             <p id="question-text"></p>

--- a/app/javascript/packs/topic23_without_timer.js
+++ b/app/javascript/packs/topic23_without_timer.js
@@ -14,7 +14,7 @@
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
       <div class="devise-form">
-        <div class="form-table" id="game-content">
+        <div class="form-table">
           <div id="question-section" style="display: none;">
             <p id="question-text"></p>
             <input type="number" id="answer-input" />

--- a/app/javascript/packs/topic24_with_timer.js
+++ b/app/javascript/packs/topic24_with_timer.js
@@ -17,7 +17,7 @@
     const gameContent = document.createElement('div');
     gameContent.innerHTML = `
       <div class="devise-form">
-        <div class="form-table" id="game-content">
+        <div class="form-table">
           <div id="question-section" style="display: none;">
             <p>You have <span id="timer">60</span> seconds.</p>
             <p id="question-text"></p>

--- a/app/views/topics/play.html.erb
+++ b/app/views/topics/play.html.erb
@@ -12,7 +12,7 @@
 </div>
 
 <%# this is where the game will go %>
-<div id="game-container" style="display: none;" data-user-signed-in="<%= user_signed_in? %>"></div>
+<div id="game-container" style="display: none !important;" data-user-signed-in="<%= user_signed_in? %>"></div>
 
 <script>
   document.addEventListener("turbo:load", function () {
@@ -23,6 +23,8 @@
     const useTimerCheckbox = document.getElementById("use-timer");
     const gameContainer = document.getElementById("game-container");
     const gameIndex = <%= @topic.id %>;
+
+    gameContainer.style.display = "none";
 
     if (!playButton) return; // Prevents error if element doesn't exist
 


### PR DESCRIPTION
Introducing turbo in order to solve the refresh issue created a few side bugs, for example, there was an extra form displayed at the bottom of each play index. This PR fixes that bug. 