### PR TITLE
Allow Incorrect Answers to Increment by Question

### DIFF
--- a/app/javascript/packs/topic12_with_timer.js
+++ b/app/javascript/packs/topic12_with_timer.js
@@ -4,6 +4,7 @@
   let totalQuestions = 0; 
   let correctAnswers = 0;
   let nextValue = 0;
+  let currentQuestionCounted = false;
 
   if (!gameContainer) {
     console.error("Game container not found");
@@ -122,9 +123,14 @@
       currentValue = nextValue;
       generateQuestion();
     } else {
-      totalQuestions += 1;
+      if (!currentQuestionCounted) {
+            totalQuestions += 1;
+            currentQuestionCounted = true;
+          }
       feedback.textContent = "Try again!";
     }
+
+    currentQuestionCounted = false;
   };
 
   answerInput.addEventListener('keydown', (event) => {

--- a/app/javascript/packs/topic13_with_timer.js
+++ b/app/javascript/packs/topic13_with_timer.js
@@ -4,6 +4,7 @@
     let totalQuestions = 0; 
     let correctAnswers = 0;
     let nextValue = 0;
+    let currentQuestionCounted = false;
   
     if (!gameContainer) {
       console.error("Game container not found");
@@ -117,9 +118,14 @@
         currentValue = nextValue;
         generateQuestion();
       } else {
-        totalQuestions += 1;
+        if (!currentQuestionCounted) {
+            totalQuestions += 1;
+            currentQuestionCounted = true;
+          }
         feedback.textContent = "Try again!";
       }
+
+      currentQuestionCounted = false;
     };
 
     answerInput.addEventListener('keydown', (event) => {

--- a/app/javascript/packs/topic14_with_timer.js
+++ b/app/javascript/packs/topic14_with_timer.js
@@ -4,6 +4,7 @@
     let totalQuestions = 0; 
     let correctAnswers = 0;
     let nextValue = 0;
+    let currentQuestionCounted = false;
   
     if (!gameContainer) {
       console.error("Game container not found");
@@ -117,9 +118,14 @@
         currentValue = nextValue;
         generateQuestion();
       } else {
-        totalQuestions += 1;
+        if (!currentQuestionCounted) {
+            totalQuestions += 1;
+            currentQuestionCounted = true;
+          }
         feedback.textContent = "Try again!";
       }
+
+      currentQuestionCounted = false;
     };
 
     answerInput.addEventListener('keydown', (event) => {

--- a/app/javascript/packs/topic15_with_timer.js
+++ b/app/javascript/packs/topic15_with_timer.js
@@ -4,6 +4,7 @@
     let totalQuestions = 0; 
     let correctAnswers = 0;
     let nextValue = 0;
+    let currentQuestionCounted = false;
   
     if (!gameContainer) {
       console.error("Game container not found");
@@ -109,9 +110,14 @@
         currentValue = nextValue;
         generateQuestion();
       } else {
-        totalQuestions += 1;
+        if (!currentQuestionCounted) {
+            totalQuestions += 1;
+            currentQuestionCounted = true;
+          }
         feedback.textContent = "Try again!";
       }
+
+      currentQuestionCounted = false;
     };
 
     answerInput.addEventListener('keydown', (event) => {

--- a/app/javascript/packs/topic16_with_timer.js
+++ b/app/javascript/packs/topic16_with_timer.js
@@ -4,6 +4,7 @@
     let totalQuestions = 0; 
     let correctAnswers = 0;
     let nextValue = 0;
+    let currentQuestionCounted = false;
   
     if (!gameContainer) {
       console.error("Game container not found");
@@ -109,9 +110,14 @@
         currentValue = nextValue;
         generateQuestion();
       } else {
-        totalQuestions += 1;
+        if (!currentQuestionCounted) {
+            totalQuestions += 1;
+            currentQuestionCounted = true;
+          }
         feedback.textContent = "Try again!";
       }
+
+      currentQuestionCounted = false;
     };
 
     answerInput.addEventListener('keydown', (event) => {

--- a/app/javascript/packs/topic17_with_timer.js
+++ b/app/javascript/packs/topic17_with_timer.js
@@ -4,6 +4,7 @@
     let totalQuestions = 0; 
     let correctAnswers = 0;
     let nextValue = 0;
+    let currentQuestionCounted = false;
   
     if (!gameContainer) {
       console.error("Game container not found");
@@ -109,9 +110,14 @@
         currentValue = nextValue;
         generateQuestion();
       } else {
-        totalQuestions += 1;
+        if (!currentQuestionCounted) {
+            totalQuestions += 1;
+            currentQuestionCounted = true;
+          }
         feedback.textContent = "Try again!";
       }
+
+      currentQuestionCounted = false;
     };
 
     answerInput.addEventListener('keydown', (event) => {

--- a/app/javascript/packs/topic18_with_timer.js
+++ b/app/javascript/packs/topic18_with_timer.js
@@ -4,6 +4,7 @@
     let totalQuestions = 0; 
     let correctAnswers = 0;
     let nextValue = 0;
+    let currentQuestionCounted = false;
   
     if (!gameContainer) {
       console.error("Game container not found");
@@ -109,9 +110,14 @@
         currentValue = nextValue;
         generateQuestion();
       } else {
-        totalQuestions += 1;
+        if (!currentQuestionCounted) {
+            totalQuestions += 1;
+            currentQuestionCounted = true;
+          }
         feedback.textContent = "Try again!";
       }
+
+      currentQuestionCounted = false;
     };
 
     answerInput.addEventListener('keydown', (event) => {

--- a/app/javascript/packs/topic19_with_timer.js
+++ b/app/javascript/packs/topic19_with_timer.js
@@ -4,6 +4,7 @@
     let totalQuestions = 0; 
     let correctAnswers = 0;
     let nextValue = 0;
+    let currentQuestionCounted = false;
   
     if (!gameContainer) {
       console.error("Game container not found");
@@ -109,9 +110,14 @@
         currentValue = nextValue;
         generateQuestion();
       } else {
-        totalQuestions += 1;
+        if (!currentQuestionCounted) {
+            totalQuestions += 1;
+            currentQuestionCounted = true;
+          }
         feedback.textContent = "Try again!";
       }
+
+      currentQuestionCounted = false;
     };
 
     answerInput.addEventListener('keydown', (event) => {

--- a/app/javascript/packs/topic1_with_timer.js
+++ b/app/javascript/packs/topic1_with_timer.js
@@ -4,6 +4,7 @@
     let totalQuestions = 0; 
     let correctAnswers = 0;
     let answer = 0;
+    let currentQuestionCounted = false;
   
     if (!gameContainer) {
       console.error("Game container not found");
@@ -89,9 +90,14 @@
       
       generateQuestion();
       } else {
-      totalQuestions += 1;
+      if (!currentQuestionCounted) {
+            totalQuestions += 1;
+            currentQuestionCounted = true;
+          }
       feedback.textContent = "Try again!";
       }
+
+      currentQuestionCounted = false;
   };
 
   answerInput.addEventListener('keydown', (event) => {

--- a/app/javascript/packs/topic20_with_timer.js
+++ b/app/javascript/packs/topic20_with_timer.js
@@ -4,6 +4,7 @@
     let totalQuestions = 0; 
     let correctAnswers = 0;
     let nextValue = 0;
+    let currentQuestionCounted = false;
   
     if (!gameContainer) {
       console.error("Game container not found");
@@ -109,9 +110,14 @@
         currentValue = nextValue;
         generateQuestion();
       } else {
-        totalQuestions += 1;
+        if (!currentQuestionCounted) {
+            totalQuestions += 1;
+            currentQuestionCounted = true;
+          }
         feedback.textContent = "Try again!";
       }
+
+      currentQuestionCounted = false;
     };
 
     answerInput.addEventListener('keydown', (event) => {

--- a/app/javascript/packs/topic21_with_timer.js
+++ b/app/javascript/packs/topic21_with_timer.js
@@ -4,6 +4,7 @@
     let totalQuestions = 0; 
     let correctAnswers = 0;
     let nextValue = 0;
+    let currentQuestionCounted = false;
   
     if (!gameContainer) {
       console.error("Game container not found");
@@ -109,9 +110,14 @@
         currentValue = nextValue;
         generateQuestion();
       } else {
-        totalQuestions += 1;
+        if (!currentQuestionCounted) {
+            totalQuestions += 1;
+            currentQuestionCounted = true;
+          }
         feedback.textContent = "Try again!";
       }
+
+      currentQuestionCounted = false;
     };
 
     answerInput.addEventListener('keydown', (event) => {

--- a/app/javascript/packs/topic22_with_timer.js
+++ b/app/javascript/packs/topic22_with_timer.js
@@ -4,6 +4,7 @@
     let totalQuestions = 0; 
     let correctAnswers = 0;
     let nextValue = 0;
+    let currentQuestionCounted = false;
   
     if (!gameContainer) {
       console.error("Game container not found");
@@ -109,9 +110,14 @@
         currentValue = nextValue;
         generateQuestion();
       } else {
-        totalQuestions += 1;
+        if (!currentQuestionCounted) {
+            totalQuestions += 1;
+            currentQuestionCounted = true;
+          }
         feedback.textContent = "Try again!";
       }
+
+      currentQuestionCounted = false;
     };
 
     answerInput.addEventListener('keydown', (event) => {

--- a/app/javascript/packs/topic23_with_timer.js
+++ b/app/javascript/packs/topic23_with_timer.js
@@ -4,6 +4,7 @@
     let totalQuestions = 0; 
     let correctAnswers = 0;
     let nextValue = 0;
+    let currentQuestionCounted = false;
   
     if (!gameContainer) {
       console.error("Game container not found");
@@ -109,9 +110,14 @@
         currentValue = nextValue;
         generateQuestion();
       } else {
-        totalQuestions += 1;
+        if (!currentQuestionCounted) {
+            totalQuestions += 1;
+            currentQuestionCounted = true;
+          }
         feedback.textContent = "Try again!";
       }
+
+      currentQuestionCounted = false;
     };
 
     answerInput.addEventListener('keydown', (event) => {

--- a/app/javascript/packs/topic24_with_timer.js
+++ b/app/javascript/packs/topic24_with_timer.js
@@ -4,6 +4,7 @@
     let totalQuestions = 0; 
     let correctAnswers = 0;
     let nextValue = 0;
+    let currentQuestionCounted = false;
   
     if (!gameContainer) {
       console.error("Game container not found");
@@ -109,9 +110,14 @@
         currentValue = nextValue;
         generateQuestion();
       } else {
-        totalQuestions += 1;
+        if (!currentQuestionCounted) {
+            totalQuestions += 1;
+            currentQuestionCounted = true;
+          }
         feedback.textContent = "Try again!";
       }
+
+      currentQuestionCounted = false;
     };
 
     answerInput.addEventListener('keydown', (event) => {

--- a/app/javascript/packs/topic25_with_timer.js
+++ b/app/javascript/packs/topic25_with_timer.js
@@ -4,6 +4,7 @@
     let totalQuestions = 0; 
     let correctAnswers = 0;
     let nextValue = 0;
+    let currentQuestionCounted = false;
   
     if (!gameContainer) {
       console.error("Game container not found");
@@ -109,9 +110,14 @@
         currentValue = nextValue;
         generateQuestion();
       } else {
-        totalQuestions += 1;
+        if (!currentQuestionCounted) {
+      totalQuestions += 1;
+      currentQuestionCounted = true;
+    }
         feedback.textContent = "Try again!";
       }
+
+      currentQuestionCounted = false;
     };
 
     answerInput.addEventListener('keydown', (event) => {

--- a/app/javascript/packs/topic2_with_timer.js
+++ b/app/javascript/packs/topic2_with_timer.js
@@ -4,6 +4,7 @@
     let totalQuestions = 0; 
     let correctAnswers = 0;
     let answer = 0;
+    let currentQuestionCounted = false;
   
     if (!gameContainer) {
       console.error("Game container not found");
@@ -89,9 +90,14 @@
       
       generateQuestion();
       } else {
-      totalQuestions += 1;
+      if (!currentQuestionCounted) {
+            totalQuestions += 1;
+            currentQuestionCounted = true;
+          }
       feedback.textContent = "Try again!";
       }
+
+      currentQuestionCounted = false;
   };
 
   answerInput.addEventListener('keydown', (event) => {

--- a/app/javascript/packs/topic3_with_timer.js
+++ b/app/javascript/packs/topic3_with_timer.js
@@ -4,6 +4,7 @@
     let totalQuestions = 0; 
     let correctAnswers = 0;
     let answer = 0;
+    let currentQuestionCounted = false;
   
     if (!gameContainer) {
       console.error("Game container not found");
@@ -89,9 +90,14 @@
       
       generateQuestion();
       } else {
-      totalQuestions += 1;
+      if (!currentQuestionCounted) {
+            totalQuestions += 1;
+            currentQuestionCounted = true;
+          }
       feedback.textContent = "Try again!";
       }
+
+      currentQuestionCounted = false;
   };
 
   answerInput.addEventListener('keydown', (event) => {

--- a/app/javascript/packs/topic4_with_timer.js
+++ b/app/javascript/packs/topic4_with_timer.js
@@ -4,6 +4,7 @@
     let totalQuestions = 0; 
     let correctAnswers = 0;
     let answer = 0;
+    let currentQuestionCounted = false;
   
     if (!gameContainer) {
       console.error("Game container not found");
@@ -89,9 +90,14 @@
       
       generateQuestion();
       } else {
-      totalQuestions += 1;
+      if (!currentQuestionCounted) {
+            totalQuestions += 1;
+            currentQuestionCounted = true;
+          }
       feedback.textContent = "Try again!";
       }
+
+      currentQuestionCounted = false;
   };
 
   answerInput.addEventListener('keydown', (event) => {

--- a/app/javascript/packs/topic5_with_timer.js
+++ b/app/javascript/packs/topic5_with_timer.js
@@ -4,6 +4,7 @@
     let totalQuestions = 0; 
     let correctAnswers = 0;
     let answer = 0;
+    let currentQuestionCounted = false;
   
     if (!gameContainer) {
       console.error("Game container not found");
@@ -89,9 +90,14 @@
       
       generateQuestion();
       } else {
-      totalQuestions += 1;
+      if (!currentQuestionCounted) {
+            totalQuestions += 1;
+            currentQuestionCounted = true;
+          }
       feedback.textContent = "Try again!";
       }
+
+      currentQuestionCounted = false;
   };
 
   answerInput.addEventListener('keydown', (event) => {

--- a/app/javascript/packs/topic8_with_timer.js
+++ b/app/javascript/packs/topic8_with_timer.js
@@ -4,6 +4,7 @@
     let totalQuestions = 0; 
     let correctAnswers = 0;
     let tenFrameValue = 0;
+    let currentQuestionCounted = false;
   
     if (!gameContainer) {
       console.error("Game container not found");
@@ -95,9 +96,14 @@
             generateQuestion();
         }, 2000);
         } else {
-        totalQuestions += 1;
+        if (!currentQuestionCounted) {
+            totalQuestions += 1;
+            currentQuestionCounted = true;
+          }
         feedback.textContent = "Try again!";
         }
+
+        currentQuestionCounted = false;
     };
 
     answerInput.addEventListener('keydown', (event) => {

--- a/app/javascript/packs/topic9_with_timer.js
+++ b/app/javascript/packs/topic9_with_timer.js
@@ -4,6 +4,7 @@
     let totalQuestions = 0; 
     let correctAnswers = 0;
     let tenFrameValue = 0;
+    let currentQuestionCounted = false;
   
     if (!gameContainer) {
       console.error("Game container not found");
@@ -95,9 +96,14 @@
             generateQuestion();
         }, 2000);
         } else {
-        totalQuestions += 1;
+        if (!currentQuestionCounted) {
+            totalQuestions += 1;
+            currentQuestionCounted = true;
+          }
         feedback.textContent = "Try again!";
         }
+
+        currentQuestionCounted = false;
     };
 
     answerInput.addEventListener('keydown', (event) => {


### PR DESCRIPTION
Currently, when a user incorrectly answers a question multiple times, the incorrect answer is incremented no once per question, but once per incorrect answer. This PR adjusts logic such that an incorrect answer is only counted once per question, rather than multiple times per question for multiple incorrect tries on the same question. 