### PR TITLE
Add Category to Topics

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,6 +1,11 @@
 class TopicsController < ApplicationController
   def index
-    @topics = Topic.all
+    if params[:category].present?
+      @category = Topic::CATEGORIES.find { |cat| cat.parameterize == params[:category] }
+      @topics = Topic.where(category: @category) if @category
+    else
+      @categories = Topic.distinct.pluck(:category)
+    end
   end
 
   def show

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,7 +1,10 @@
 class Topic < ApplicationRecord
   has_many :questions, dependent: :destroy
 
+  CATEGORIES = [ "Addition and Subtraction", "Multiplication", "Number Bonds", "Ten Frames", "Rainbow Pairs" ]
+
   validates :title, presence: true, uniqueness: true
+  validates :category, presence: true, inclusion: { in: CATEGORIES }
 
   private
 end

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -1,34 +1,67 @@
-<div class="topics-home main-btn-group">
-    <% @topics.each do |topic| %>
-        <% if topic.public? || user_signed_in? %>
-            <%= link_to topic_path(topic) do %>
+
+<% if @categories.present? %>
+    <div class="topics-home main-btn-group">
+        <% @categories.each do |category| %>
+        <%= link_to category_topics_path(category: category.parameterize) do %>
             <div class="main-btn-group">
                 <button class="main-btn">
-                    <% if topic.title.downcase.include?("rainbow") %>
-                        <%= image_tag("https://res.cloudinary.com/dm37aktki/image/upload/v1745229391/alex-jackman-_Bk2NVFx7q4-unsplash_kj7up7.jpg", class: "main-btn-icon") %>
-                    <% elsif topic.title.downcase.include?("number bond") %>
-                        <%= image_tag("https://res.cloudinary.com/dm37aktki/image/upload/v1745253609/MentalMaths/Screenshot_2025-04-21_at_17.39.05_kaqu1y.png", class: "main-btn-icon") %>
-                    <% elsif topic.title.downcase.include?("multiplication") %>
+                    <% if category.downcase.include?("addition") || category.downcase.include?("subtraction") %>
+                        <%= image_tag("https://res.cloudinary.com/dm37aktki/image/upload/v1745252577/MentalMaths/behnam-norouzi-wBKWM-DLhzg-unsplash_qyw75q.jpg", class: "main-btn-icon") %>
+                    <% elsif category.downcase.include?("multiplication") %>
                         <%= image_tag("https://res.cloudinary.com/dm37aktki/image/upload/v1745253579/MentalMaths/frogses-production-FlvBhEwEOng-unsplash_uiybkh.jpg", class: "main-btn-icon") %>
-                    <% elsif topic.title.downcase.include?("ten frame") %>
+                    <% elsif category.downcase.include?("number bond") %>
+                        <%= image_tag("https://res.cloudinary.com/dm37aktki/image/upload/v1745253609/MentalMaths/Screenshot_2025-04-21_at_17.39.05_kaqu1y.png", class: "main-btn-icon") %>
+                    <% elsif category.downcase.include?("ten frame") %>
                         <%= image_tag("https://res.cloudinary.com/dm37aktki/image/upload/v1745253598/MentalMaths/Screenshot_2025-04-21_at_17.36.02_z8dbr4.png", class: "main-btn-icon") %>
+                    <% elsif category.downcase.include?("rainbow") %>
+                        <%= image_tag("https://res.cloudinary.com/dm37aktki/image/upload/v1745229391/alex-jackman-_Bk2NVFx7q4-unsplash_kj7up7.jpg", class: "main-btn-icon")%>
                     <% else %>
                         <%= image_tag("https://res.cloudinary.com/dm37aktki/image/upload/v1745252577/MentalMaths/behnam-norouzi-wBKWM-DLhzg-unsplash_qyw75q.jpg", class: "main-btn-icon") %>
                     <% end %>
-                    <h4><%= topic.title %></h4>
+                    <h4><%= category.titleize %></h4>
                 </button>
             </div>
-            <% end %>
-        <% else %>
-            <%= link_to new_user_registration_path do %>
-                <button class="main-btn locked">
-                    <h1>🔒</h1>
-                    <h4><%= topic.title %></h4>
-                </button>
-            <% end %>
         <% end %>
+        <% end %>
+    </div>
+
+<% elsif @topics.present? %>
+  <h2><%= @category %></h2>
+  <div class="topics-home main-btn-group">
+    <% @topics.each do |topic| %>
+      <% if topic.public? || user_signed_in? %>
+        <%= link_to topic_path(topic) do %>
+          <div class="main-btn-group">
+            <button class="main-btn">
+                <% if topic.category.downcase.include?("addition") %>
+                    <%= image_tag("https://res.cloudinary.com/dm37aktki/image/upload/v1745252577/MentalMaths/behnam-norouzi-wBKWM-DLhzg-unsplash_qyw75q.jpg", class: "main-btn-icon") %>
+                <% elsif topic.category.downcase.include?("multiplication") %>
+                    <%= image_tag("https://res.cloudinary.com/dm37aktki/image/upload/v1745253579/MentalMaths/frogses-production-FlvBhEwEOng-unsplash_uiybkh.jpg", class: "main-btn-icon") %>
+                <% elsif topic.category.downcase.include?("number bond") %>
+                    <%= image_tag("https://res.cloudinary.com/dm37aktki/image/upload/v1745253609/MentalMaths/Screenshot_2025-04-21_at_17.39.05_kaqu1y.png", class: "main-btn-icon") %>
+                <% elsif topic.category.downcase.include?("ten frame") %>
+                    <%= image_tag("https://res.cloudinary.com/dm37aktki/image/upload/v1745253598/MentalMaths/Screenshot_2025-04-21_at_17.36.02_z8dbr4.png", class: "main-btn-icon") %>
+                <% elsif topic.category.downcase.include?("rainbow") %>
+                    <%= image_tag("https://res.cloudinary.com/dm37aktki/image/upload/v1745229391/alex-jackman-_Bk2NVFx7q4-unsplash_kj7up7.jpg", class: "main-btn-icon")%>
+                <% else %>
+                    <%= image_tag("https://res.cloudinary.com/dm37aktki/image/upload/v1745252577/MentalMaths/behnam-norouzi-wBKWM-DLhzg-unsplash_qyw75q.jpg", class: "main-btn-icon") %>
+                <% end %>
+              <h4><%= topic.title %></h4>
+            </button>
+          </div>
+        <% end %>
+      <% else %>
+        <%= link_to new_user_registration_path do %>
+          <button class="main-btn locked">
+            <h1>🔒</h1>
+            <h4><%= topic.title %></h4>
+          </button>
+        <% end %>
+      <% end %>
     <% end %>
-</div>
+  </div>
+<% end %>
+
 
 <script>
     document.querySelectorAll('.main-btn').forEach(btn => {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,9 @@ Rails.application.routes.draw do
 
     # Routes for topics
     resources :topics, only: [ :index, :show ] do
+      collection do
+        get "category/:category", to: "topics#index", as: :category
+      end
       # Route to show questions for a specific topic (will handle the intro and question display)
       #   member do
       member do

--- a/db/migrate/20250615154659_add_category_to_topics.rb
+++ b/db/migrate/20250615154659_add_category_to_topics.rb
@@ -1,0 +1,5 @@
+class AddCategoryToTopics < ActiveRecord::Migration[8.0]
+  def change
+    add_column :topics, :category, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_18_195125) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_15_154659) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -48,6 +48,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_18_195125) do
     t.datetime "updated_at", null: false
     t.boolean "public"
     t.boolean "requires_auth"
+    t.string "category"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,175 +15,204 @@ topics = [
     title: "Rainbow Pairs (0-10)",
     intro: "Rainbow Pairs help us get to 10 easily. See the rainbow below for number pairs that add up to 10!",
     public: true,
-    requires_auth: false
+    requires_auth: false,
+    category: "Rainbow Pairs"
   },
   {
     title: "Rainbow Pairs (1-100)",
     intro: "Building upon Rainbow Pairs (0-10). This time we use the same idea, except with tens adding up to 100. See the rainbow below!",
     public: false,
-    requires_auth: true
+    requires_auth: true,
+    category: "Rainbow Pairs"
   },
   {
     title: "Rainbow Pairs (0-1000)",
     intro: "Building upon Rainbow Pairs (0-10) and Rainbow Pairs (0-100). This time we use the same idea, except with hundreds adding up to 1000. See the rainbow below!",
     public: false,
-    requires_auth: true
+    requires_auth: true,
+    category: "Rainbow Pairs"
   },
   {
     title: "Adding to the Nearest Ten",
     intro: "Use our knowledge of Rainbow Pairs to guess the number that would bring us to our next multiple of ten.",
     public: true,
-    requires_auth: false
+    requires_auth: false,
+    category: "Addition and Subtraction"
   },
   {
     title: "Subtracting to the Nearest Ten",
     intro: "Use our knowledge of Rainbow Pairs to guess the number that would bring us to our previous multiple of ten",
     public: false,
-    requires_auth: true
+    requires_auth: true,
+    category: "Addition and Subtraction"
   },
   {
     title: "Number Bonds: Two-Digit Plus One-Digit",
     intro: "Use the number bonds and your knowledge of rainbow pairs to solve. See example below.",
     public: false,
-    requires_auth: true
+    requires_auth: true,
+    category: "Number Bonds"
   },
   {
     title: "Number Bonds: Two-Digit Minus One-Digit",
     intro: "Use the number bonds and your knowledge of rainbow pairs to solve. See example below.",
     public: false,
-    requires_auth: true
+    requires_auth: true,
+    category: "Number Bonds"
   },
   {
     title: "Subitizing with Ten Frames (0-10)",
     intro: "Visualize groups of 5 and 10 by selecting the number of dots you see. See the examples below.",
     public: true,
-    requires_auth: false
+    requires_auth: false,
+    category: "Ten Frames"
   },
   {
     title: "Subitizing with Ten Frames (10-20)",
     intro: "Visualize groups of 5 and 10 by selecting the number of dots you see. See the examples below.",
     public: false,
-    requires_auth: true
+    requires_auth: true,
+    category: "Ten Frames"
   },
   {
     title: "Number Bonds: Two-Digit Plus Two-Digit",
     intro: "Break the two-digit number apart to solve. See example below.",
     public: false,
-    requires_auth: true
+    requires_auth: true,
+    category: "Number Bonds"
   },
   {
     title: "Number Bonds: Two-Digit Minus Two-Digit",
     intro: "Break the two-digit number apart to solve. See example below.",
     public: false,
-    requires_auth: true
+    requires_auth: true,
+    category: "Number Bonds"
   },
   {
     title: "Count Up and Down By ... From ...",
     intro: "Choose a number to start from. Then choose a number by which to count up and down. See the example below.",
     public: true,
-    requires_auth: false
+    requires_auth: false,
+    category: "Addition and Subtraction"
   },
   {
     title: "Add and Subtract by 10",
     intro: "Pay special attention to the tens place when you add or subtract 10 each time.",
     public: false,
-    requires_auth: true
+    requires_auth: true,
+    category: "Addition and Subtraction"
   },
   {
     title: "Add and Subtract by 100",
     intro: "Pay special attention to the hundreds place when you add or subtract 100 each time.",
     public: false,
-    requires_auth: true
+    requires_auth: true,
+    category: "Addition and Subtraction"
   },
   {
     title: "Multiplication as Repeated Addition: 2",
     intro: "Practice multiplication as groups of a certain number added together. Add or subtract by 2 starting from 0.",
     public: false,
-    requires_auth: true
+    requires_auth: true,
+    category: "Multiplication"
   },
   {
     title: "Multiplication as Repeated Addition: 3",
     intro: "Practice multiplication as groups of a certain number added together. Add or subtract by 3 starting from 0.",
     public: false,
-    requires_auth: true
+    requires_auth: true,
+    category: "Multiplication"
   },
   {
     title: "Multiplication as Repeated Addition: 4",
     intro: "Practice multiplication as groups of a certain number added together. Add or subtract by 4 starting from 0.",
     public: false,
-    requires_auth: true
+    requires_auth: true,
+    category: "Multiplication"
   },
   {
     title: "Multiplication as Repeated Addition: 5",
     intro: "Practice multiplication as groups of a certain number added together. Add or subtract by 5 starting from 0.",
     public: false,
-    requires_auth: true
+    requires_auth: true,
+    category: "Multiplication"
   },
   {
     title: "Multiplication as Repeated Addition: 6",
     intro: "Practice multiplication as groups of a certain number added together. Add or subtract by 6 starting from 0.",
     public: false,
-    requires_auth: true
+    requires_auth: true,
+    category: "Multiplication"
   },
   {
     title: "Multiplication as Repeated Addition: 7",
     intro: "Practice multiplication as groups of a certain number added together. Add or subtract by 7 starting from 0.",
     public: false,
-    requires_auth: true
+    requires_auth: true,
+    category: "Multiplication"
   },
   {
     title: "Multiplication as Repeated Addition: 8",
     intro: "Practice multiplication as groups of a certain number added together. Add or subtract by 8 starting from 0.",
     public: false,
-    requires_auth: true
+    requires_auth: true,
+    category: "Multiplication"
   },
   {
     title: "Multiplication as Repeated Addition: 9",
     intro: "Practice multiplication as groups of a certain number added together. Add or subtract by 0 starting from 0.",
     public: false,
-    requires_auth: true
+    requires_auth: true,
+    category: "Multiplication"
   },
   {
     title: "Multiplication as Repeated Addition: 10",
     intro: "Practice multiplication as groups of a certain number added together. Add or subtract by 10 starting from 0.",
     public: false,
-    requires_auth: true
+    requires_auth: true,
+    category: "Multiplication"
   },
   {
     title: "Multiplication as Repeated Addition: 11",
     intro: "Practice multiplication as groups of a certain number added together. Add or subtract by 11 starting from 0.",
     public: false,
-    requires_auth: true
+    requires_auth: true,
+    category: "Multiplication"
   },
   {
     title: "Multiplication as Repeated Addition: 12",
     intro: "Practice multiplication as groups of a certain number added together. Add or subtract by 12 starting from 0.",
     public: false,
-    requires_auth: true
+    requires_auth: true,
+    category: "Multiplication"
   },
   {
     title: "Number Bond Fact Families: 1 - 10",
     intro: "List and solve all fact families for a number.",
     public: true,
-    requires_auth: false
+    requires_auth: false,
+    category: "Number Bonds"
   },
   {
     title: "Number Bond Fact Families: Two-Digit",
     intro: "List and solve all fact families for a number.",
     public: false,
-    requires_auth: true
+    requires_auth: true,
+    category: "Number Bonds"
   },
   {
     title: "Number Bond Fact Families: Three-Digit",
     intro: "List and solve all fact families for a number.",
     public: false,
-    requires_auth: true
+    requires_auth: true,
+    category: "Number Bonds"
   },
   {
     title: "Two-Digit Multiplication",
     intro: "Use a number bont to help you solve two-digit multiplication.",
     public: false,
-    requires_auth: true
+    requires_auth: true,
+    category: "Multiplication"
   }
 ]
 


### PR DESCRIPTION
Currently the large amount of topics makes the topics page difficult to digest. As a result, this PR added a category field to the topic. The topic index now originally features just the category buttons, and when the user selects a category, all the topics related only to that category are displayed. 