### PR TITLE
Update Score view for Family and Teacher

### DIFF
--- a/app/controllers/scores_controller.rb
+++ b/app/controllers/scores_controller.rb
@@ -1,9 +1,45 @@
 class ScoresController < ApplicationController
   before_action :authenticate_user!
 
-  def index
+def index
+  if current_user.student?
+    # Students see their own scores
     @scores = current_user.scores.includes(:topic).order(created_at: :desc).page(params[:page])
+
+  elsif current_user.family?
+    # Families must pass a child_id param
+    if params[:child_id].present?
+      @child = current_user.children.find_by(id: params[:child_id])
+
+      if @child
+        @scores = @child.scores.includes(:topic).order(created_at: :desc).page(params[:page])
+      else
+        redirect_to family_dashboard_path, alert: "Child not found or not authorized."
+      end
+    else
+      redirect_to family_dashboard_path, alert: "Please select a child to view scores."
+    end
+
+  elsif current_user.teacher?
+    # Teachers must pass a student_id param
+    if params[:student_id].present?
+      # Only allow students enrolled in the teacher's classrooms
+      student = User.find_by(id: params[:student_id])
+
+      if student&.student? && (student.enrolled_classrooms & current_user.classrooms).any?
+        @scores = student.scores.includes(:topic).order(created_at: :desc).page(params[:page])
+      else
+        redirect_to teacher_dashboard_path, alert: "Student not found or not authorized."
+      end
+    else
+      redirect_to teacher_dashboard_path, alert: "Please select a student to view scores."
+    end
+
+  else
+    redirect_to root_path, alert: "You are not authorized to view scores."
   end
+end
+
 
   def create
     # Safely permit params with strong params

--- a/app/views/scores/index.html.erb
+++ b/app/views/scores/index.html.erb
@@ -1,3 +1,14 @@
+<% case current_user.role.downcase %>
+<% when "student" %>
+  <h1>Scores for <%= current_user.username %></h1>
+<% when "family" %>
+  <h1>Scores for <%= current_user.children.find_by(id: params[:child_id]).username %></h1>
+<% when "teacher" %>
+  <h1>Scores for <%= User.find_by(id: params[:student_id]).username %> </h1>
+<% else %>
+  <% raise "Unsupported role: #{current_user.role}" %>
+<% end %>
+
 <% if @scores.present? %>
   <table class="score-table">
     <thead>


### PR DESCRIPTION
Current the score index shows the current user's scores. If that user is a teacher or parent, this means that it would not display that user's scores, rather than their Child's. This PR updates score index logic in order to display the student's score instead. 