### PR TITLE
Reuse Deleted Usernames

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ApplicationRecord
   # Scores
   has_many :scores
 
-  validates :username, presence: true, uniqueness: true
+  validates :username, presence: true, uniqueness: { conditions: -> { where.not(classroom_id: nil) } }
   validates :email, presence: true, unless: :student_or_child?
   validates :email, uniqueness: true, allow_blank: true
 

--- a/db/migrate/20250715180006_add_scoped_unique_index_to_users.rb
+++ b/db/migrate/20250715180006_add_scoped_unique_index_to_users.rb
@@ -1,0 +1,12 @@
+class AddScopedUniqueIndexToUsers < ActiveRecord::Migration[8.0]
+  def change
+    # If you already have a global index on username, remove it first
+    remove_index :users, :username if index_exists?(:users, :username)
+
+    # Add a **partial** unique index: only enforce uniqueness when classroom_id is present
+    add_index :users, :username,
+      unique: true,
+      where: "classroom_id IS NOT NULL",
+      name: "index_users_on_username_for_students"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_06_194009) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_15_180006) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -97,7 +97,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_06_194009) do
     t.index ["classroom_id"], name: "index_users_on_classroom_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["school_id"], name: "index_users_on_school_id"
-    t.index ["username"], name: "index_users_on_username", unique: true
+    t.index ["username"], name: "index_users_on_username_for_students", unique: true, where: "(classroom_id IS NOT NULL)"
   end
 
   add_foreign_key "classrooms", "users", column: "teacher_id"


### PR DESCRIPTION
Currently, when a user is deleted the user is not removed from the db. Rather, the user's classroom is set to nil. This means that the uniqueness contraint prevents the teacher from adding the same username again even if inactive. This PR restricts the uniqueness contstraint to active users only 